### PR TITLE
Updated relative CMakelists and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ The compression libraries and executables zlib, gzip, libbzip, and bzip2 are all
 
 Doxygen is a documentation system to extract comments that have been placed inline in the source code. See the section below entitled "Software Documentation" for more information.
 
+To install on debian based systems please run
+
+```
+sudo apt install cmake gcc g++ libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-serialization-dev libboost-mpi-dev doxygen 
+```
+
 
 ###  Boost library
 

--- a/src/cmake/boost.cmake
+++ b/src/cmake/boost.cmake
@@ -41,6 +41,8 @@ if (NOT Boost_FOUND)
   ##    Helpful if there are conflicts between locally and system-installed versions
   set (Boost_NO_BOOST_CMAKE OFF)
 
+set(BOOST_ROOT "/usr/include")  
+set(BOOST_LIBRARYDIR "/usr/lib/x86_64-linux-gnu") 
   set (BOOST_COMPILED_LIBRARIES program_options system filesystem serialization mpi)
   find_package (Boost 1.79.0 REQUIRED COMPONENTS ${BOOST_COMPILED_LIBRARIES})
 endif ()

--- a/src/qscores/CMakeLists.txt
+++ b/src/qscores/CMakeLists.txt
@@ -159,7 +159,7 @@ if (TARGET ${TARGET_NAME_EXEC})
   target_sources (${TARGET_NAME_EXEC} PRIVATE ${EXE_HPP_FILES})
 
   ##  Rename the executable
-  set_property (TARGET qscores_exe PROPERTY OUTPUT_NAME qscores)
+  set_property (TARGET qscores_exe PROPERTY OUTPUT_NAME qscores-archiver)
 
   if (Boost_FOUND)
     target_include_directories (${TARGET_NAME_EXEC} PUBLIC "${Boost_INCLUDE_DIRS}")


### PR DESCRIPTION
Updated some `cmakelists` as the program wouldn't install without this. Also added the install command for all the packages on debian based systems. It's worth noting I tested these commands on a fresh install of debian using [distrobox](https://distrobox.it/) and the install worked. I've attached some questions about other parts of the documentation in the form of comments